### PR TITLE
[NeoForge] Correct malformed json in eo_uy, pt_br, pt_pt translations

### DIFF
--- a/src/main/resources/assets/storagedelight/lang/eo_uy.json
+++ b/src/main/resources/assets/storagedelight/lang/eo_uy.json
@@ -44,17 +44,17 @@
   "block.storagedelight.bamboo_drawer_with_books": "Bambua Tirkesto kun Libroj",
   "block.storagedelight.pale_oak_drawer_with_books": "Hela Kverka Tirkesto kun Libroj",
 
-  "block.storagedelight.oak_bookshelf_with_door": "Kverk-libroŝranko kun Pordo"
-  "block.storagedelight.birch_bookshelf_with_door": "Betul-libroŝranko kun Pordo"
-  "block.storagedelight.spruce_bookshelf_with_door": "Pice-libroŝranko kun Pordo"
-  "block.storagedelight.cherry_bookshelf_with_door": "Ĉeriz-libroŝranko kun Pordo"
-  "block.storagedelight.jungle_bookshelf_with_door": "Ĝangal-libroŝranko kun Pordo"
-  "block.storagedelight.acacia_bookshelf_with_door": "Akacio-libroŝranko kun Pordo"
-  "block.storagedelight.dark_oak_bookshelf_with_door": "Malhelkverk-libroŝranko kun Pordo"
-  "block.storagedelight.mangrove_bookshelf_with_door": "Mangrovo-libroŝranko kun Pordo"
-  "block.storagedelight.crimson_bookshelf_with_door": "Karmzin-libroŝranko kun Pordo"
-  "block.storagedelight.warped_bookshelf_with_door": "Kurba libroŝranko kun Pordo"
-  "block.storagedelight.bamboo_bookshelf_with_door": "Bamb-libroŝranko kun Pordo"
+  "block.storagedelight.oak_bookshelf_with_door": "Kverk-libroŝranko kun Pordo",
+  "block.storagedelight.birch_bookshelf_with_door": "Betul-libroŝranko kun Pordo",
+  "block.storagedelight.spruce_bookshelf_with_door": "Pice-libroŝranko kun Pordo",
+  "block.storagedelight.cherry_bookshelf_with_door": "Ĉeriz-libroŝranko kun Pordo",
+  "block.storagedelight.jungle_bookshelf_with_door": "Ĝangal-libroŝranko kun Pordo",
+  "block.storagedelight.acacia_bookshelf_with_door": "Akacio-libroŝranko kun Pordo",
+  "block.storagedelight.dark_oak_bookshelf_with_door": "Malhelkverk-libroŝranko kun Pordo",
+  "block.storagedelight.mangrove_bookshelf_with_door": "Mangrovo-libroŝranko kun Pordo",
+  "block.storagedelight.crimson_bookshelf_with_door": "Karmzin-libroŝranko kun Pordo",
+  "block.storagedelight.warped_bookshelf_with_door": "Kurba libroŝranko kun Pordo",
+  "block.storagedelight.bamboo_bookshelf_with_door": "Bamb-libroŝranko kun Pordo",
   "block.storagedelight.pale_oak_bookshelf_with_door": "Helkverk-libroŝranko kun Pordo",
 
   "block.storagedelight.glass_oak_cabinet": "Vitra Kverka Ŝranko",

--- a/src/main/resources/assets/storagedelight/lang/pt_br.json
+++ b/src/main/resources/assets/storagedelight/lang/pt_br.json
@@ -45,17 +45,17 @@
   "block.storagedelight.bamboo_drawer_with_books": "Gaveta de Bambu com Livros",
   "block.storagedelight.pale_oak_drawer_with_books": "Gaveta de Carvalho Claro com Livros",
 
-  "block.storagedelight.oak_bookshelf_with_door": "Estante de Carvalho com Porta"
-  "block.storagedelight.birch_bookshelf_with_door": "Estante de Bétula com Porta"
-  "block.storagedelight.spruce_bookshelf_with_door": "Estante de Pinho com Porta"
-  "block.storagedelight.cherry_bookshelf_with_door": "Estante de Cerejeira com Porta"
-  "block.storagedelight.jungle_bookshelf_with_door": "Estante de Madeira da Selva com Porta"
-  "block.storagedelight.acacia_bookshelf_with_door": "Estante de Acácia com Porta"
-  "block.storagedelight.dark_oak_bookshelf_with_door": "Estante de Carvalho Escuro com Porta"
-  "block.storagedelight.mangrove_bookshelf_with_door": "Estante de Mangue com Porta"
-  "block.storagedelight.crimson_bookshelf_with_door": "Estante Carmesim com Porta"
-  "block.storagedelight.warped_bookshelf_with_door": "Estante Torta com Porta"
-  "block.storagedelight.bamboo_bookshelf_with_door": "Estante de Bambu com Porta"
+  "block.storagedelight.oak_bookshelf_with_door": "Estante de Carvalho com Porta",
+  "block.storagedelight.birch_bookshelf_with_door": "Estante de Bétula com Porta",
+  "block.storagedelight.spruce_bookshelf_with_door": "Estante de Pinho com Porta",
+  "block.storagedelight.cherry_bookshelf_with_door": "Estante de Cerejeira com Porta",
+  "block.storagedelight.jungle_bookshelf_with_door": "Estante de Madeira da Selva com Porta",
+  "block.storagedelight.acacia_bookshelf_with_door": "Estante de Acácia com Porta",
+  "block.storagedelight.dark_oak_bookshelf_with_door": "Estante de Carvalho Escuro com Porta",
+  "block.storagedelight.mangrove_bookshelf_with_door": "Estante de Mangue com Porta",
+  "block.storagedelight.crimson_bookshelf_with_door": "Estante Carmesim com Porta",
+  "block.storagedelight.warped_bookshelf_with_door": "Estante Torta com Porta",
+  "block.storagedelight.bamboo_bookshelf_with_door": "Estante de Bambu com Porta",
   "block.storagedelight.pale_oak_bookshelf_with_door": "Estante de Carvalho Claro com Porta",
 
   "block.storagedelight.glass_oak_cabinet": "Armário de Vidro de Carvalho",

--- a/src/main/resources/assets/storagedelight/lang/pt_pt.json
+++ b/src/main/resources/assets/storagedelight/lang/pt_pt.json
@@ -45,17 +45,17 @@
   "block.storagedelight.bamboo_drawer_with_books": "Gaveta de Bambu com Livros",
   "block.storagedelight.pale_oak_drawer_with_books": "Gaveta de Carvalho Claro com Livros",
 
-  "block.storagedelight.oak_bookshelf_with_door": "Estante de Carvalho com Porta"
-  "block.storagedelight.birch_bookshelf_with_door": "Estante de Bétula com Porta"
-  "block.storagedelight.spruce_bookshelf_with_door": "Estante de Pinho com Porta"
-  "block.storagedelight.cherry_bookshelf_with_door": "Estante de Cerejeira com Porta"
-  "block.storagedelight.jungle_bookshelf_with_door": "Estante de Madeira da Selva com Porta"
-  "block.storagedelight.acacia_bookshelf_with_door": "Estante de Acácia com Porta"
-  "block.storagedelight.dark_oak_bookshelf_with_door": "Estante de Carvalho Escuro com Porta"
-  "block.storagedelight.mangrove_bookshelf_with_door": "Estante de Mangue com Porta"
-  "block.storagedelight.crimson_bookshelf_with_door": "Estante Carmesim com Porta"
-  "block.storagedelight.warped_bookshelf_with_door": "Estante Torta com Porta"
-  "block.storagedelight.bamboo_bookshelf_with_door": "Estante de Bambu com Porta"
+  "block.storagedelight.oak_bookshelf_with_door": "Estante de Carvalho com Porta",
+  "block.storagedelight.birch_bookshelf_with_door": "Estante de Bétula com Porta",
+  "block.storagedelight.spruce_bookshelf_with_door": "Estante de Pinho com Porta",
+  "block.storagedelight.cherry_bookshelf_with_door": "Estante de Cerejeira com Porta",
+  "block.storagedelight.jungle_bookshelf_with_door": "Estante de Madeira da Selva com Porta",
+  "block.storagedelight.acacia_bookshelf_with_door": "Estante de Acácia com Porta",
+  "block.storagedelight.dark_oak_bookshelf_with_door": "Estante de Carvalho Escuro com Porta",
+  "block.storagedelight.mangrove_bookshelf_with_door": "Estante de Mangue com Porta",
+  "block.storagedelight.crimson_bookshelf_with_door": "Estante Carmesim com Porta",
+  "block.storagedelight.warped_bookshelf_with_door": "Estante Torta com Porta",
+  "block.storagedelight.bamboo_bookshelf_with_door": "Estante de Bambu com Porta",
   "block.storagedelight.pale_oak_bookshelf_with_door": "Estante de Carvalho Claro com Porta",
 
   "block.storagedelight.glass_oak_cabinet": "Armário de Vidro de Carvalho",


### PR DESCRIPTION
I was getting several different exceptions thrown in Fabric from malformed json in the localizations. PR addresses this issue.

```
Failed to parse merged object 'assets/storagedelight/lang/{LANGUAGE}.json'!
com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Unterminated object at line 48 column 4 path $.item.storagedelight.oak_bookshelf_with_door
```